### PR TITLE
Fixed a bug with empty events

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
     <name>Where am I ?</name>
     <summary><![CDATA[Is a simple application to locate everybody in your company.]]></summary>
     <description><![CDATA[Is a simple application to locate everybody in your company.]]></description>
-    <version>0.0.36</version>
+    <version>0.0.37</version>
     <licence>agpl</licence>
     <author mail="contact@adacis.net" homepage="https://www.adacis.net">ADACIS</author>
     <namespace>Whereami</namespace>
@@ -12,7 +12,7 @@
 	<category>organization</category>
     <bugs>https://github.com/Adacis/whereami/issues</bugs>
     <dependencies>
-        <nextcloud min-version="29" max-version="29"/>
+        <nextcloud min-version="29" max-version="31"/>
     </dependencies>
     <settings>
         <admin>OCA\Whereami\Settings\WhereamiAdmin</admin>

--- a/lib/MyClass/MyEvent.php
+++ b/lib/MyClass/MyEvent.php
@@ -8,13 +8,13 @@ use Psr\Log\LoggerInterface;
 
 class MyEvent
 {
-    public String $id;
-    public String $summary;
-    public String $dtStart;
-    public String $dtEnd;
-    public String $place;
-    public String $place2;
-    public String $nextcloud_users;
+    public string $id;
+    public string $summary;
+    public ?string $dtStart;
+    public ?string $dtEnd;
+    public string $place;
+    public string $place2;
+    public string $nextcloud_users;
     public $quote;
 
     public bool $valid;
@@ -31,12 +31,12 @@ class MyEvent
         $this->log = $logger;
         $this->myDb             = $myDb;
         $this->id               = $e['id'];
-        $this->dtStart          = $e["objects"][0]["DTSTART"][0]?->modify('+ 1 minute')?->format('Y-m-d H:i:s');
-        $this->dtEnd            = $e["objects"][0]["DTEND"][0]?->modify('- 1 minute')?->format('Y-m-d H:i:s') ?? $this->dtStart;
+        $this->dtStart          = ($e["objects"][0]["DTSTART"][0] ?? null)?->modify('+ 1 minute')?->format('Y-m-d H:i:s');
+        $this->dtEnd            = ($e["objects"][0]["DTEND"][0] ?? null)?->modify('- 1 minute')?->format('Y-m-d H:i:s') ?? $this->dtStart;
         $this->nextcloud_users  = $this->getNameCalendar($this->id);
-        $this->summary          = str_replace("@", "", $e["objects"][0]["SUMMARY"][0]);
+        $this->summary          = str_replace("@", "", $e["objects"][0]["SUMMARY"][0] ?? '');
 
-        $tmp                    = $this->extractData(",", 0, $e["objects"][0]["SUMMARY"][0]);
+        $tmp                    = $this->extractData(",", 0, $e["objects"][0]["SUMMARY"][0] ?? '');
         if (!is_null($this->dtStart) && count($tmp) > 0) {
             $this->place = $tmp[0];
             if (count($tmp) >= 2) {
@@ -108,9 +108,12 @@ class MyEvent
         preg_match_all($re, strtolower($data), $matches, PREG_SET_ORDER, 0);
 
         try {
-            $cls = [$matches[0][1]];
-            if (count($matches[0]) >= 4) {
-                array_push($cls, $matches[0][3]);
+            $cls = [];
+            if (isset($matches[0][1])) {
+                $cls[] = $matches[0][1];
+            }
+            if (count($matches[0] ?? []) >= 4) {
+                $cls[] = $matches[0][3];
             }
         } catch (\Throwable $th) {
             $cls = [];

--- a/templates/navigation/index.php
+++ b/templates/navigation/index.php
@@ -1,5 +1,5 @@
 <ul class="app-navigation">
-    <li class="app-navigation-entry"><span class="app-title"></span><b>Where am I V 0.0.36</b></li>
+    <li class="app-navigation-entry"><span class="app-title"></span><b>Where am I V 0.0.37</b></li>
     <li class="app-navigation-entry-link">
         <ul class="app-navigation">
             <li class="active app-navigation-entry-link button new btn-new-event"><span class="navmarg icon-add"></span><a


### PR DESCRIPTION
When an event was empty (i.e. no object, no summary, almost nothing but an id, uid), the event parsing lead to a bug that would cause the application to fail loading the table of people or locations. This was mainly due to the start and end dates not being declared as possibly null when they should have been. I also cleaned up some code with array accesses that would spam a lot of errors in the Nextcloud logging because the offsets do not exist. I just used null-safe operators to set default values when this happens.